### PR TITLE
[TASK] require typo3/cms-core:>=6.2.0,<=8.7.99

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "issues": "https://forge.typo3.org/projects/extension-px-validation/issues",
         "source": "https://github.com/portrino/px_validation"
     },
+    "require": {
+        "typo3/cms-core": ">=6.2.0,<=8.7.99"
+    },
     "autoload": {
         "psr-4": {
             "Portrino\\PxValidation\\": "Classes"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = [
     [
         'depends' =>
         [
-            'typo3' => '6.2.0-7.99.99',
+            'typo3' => '6.2.0-8.7.99',
         ],
         'conflicts' =>
         [


### PR DESCRIPTION
Hi @aWuttig,
we tested the current version with TYPO3 8 and could not find any incompatibility so far. 

Would you please merge the changes on composer.json and ext_emconf.php?

cheers
Dirk